### PR TITLE
feat: add capability to attack with multipart/form-data request

### DIFF
--- a/lib/target.schema.json
+++ b/lib/target.schema.json
@@ -30,6 +30,9 @@
             }
           },
           "type": "object"
+        },
+        "multipart": {
+          "type": "object"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
- Currently on JSON format is supported
- Content type header will be populated automatically.

**Example**
```
{
  "method": "POST",
  "url": "https://localhost:8000",
  "multipart": {
    "file": "@image.webp"
  }
}
```